### PR TITLE
install.sh: Fetch latest version & add linux aarch64 support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,14 +34,15 @@
 # ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 # The views and conclusions contained in the software and documentation are those
 # of the authors and should not be interpreted as representing official policies,
 # either expressed or implied, of the FreeBSD Project.
 
 get_latest_release() {
-  echo "dev"
-  # curl --silent "https://wasmtime.sh/latest-version"
+  curl --silent "https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest" | \
+    grep tag_name | \
+    cut -d '"' -f 4
 }
 
 release_url() {

--- a/install.sh
+++ b/install.sh
@@ -465,6 +465,10 @@ check_architecture() {
   local version="$1"
   local arch="$2"
 
+  if [[ "$arch $(uname)" = "aarch64 Linux" ]]; then
+    return 0
+  fi
+
   if [[ "$version" != "local"* ]]; then
     if [ "$arch" != "x86_64" ]; then
       error "Sorry! Wasmtime currently only provides pre-built binaries for x86_64 architectures."


### PR DESCRIPTION
This updates the calculation of the current version of wasmtime to always return a stable release instead of `dev` unconditionally to alleviate issues such as https://github.com/bytecodealliance/wasmtime/issues/3851. Additionally since I noticed it I went ahead and added an "allow-list entry" for linux aarch64 since we have precompiled binaries for that platform.