### PR TITLE
fix: install.sh upgrade_is_ok check

### DIFF
--- a/_site/README.html
+++ b/_site/README.html
@@ -36,17 +36,17 @@ will check that <code>_site</code> doesn't diverge from rebuilding the original 
 <h2>Set Up</h2>
 <p>Install the <code>cobalt</code> CLI:</p>
 <pre style="background-color:#2b303b;">
-<span style="color:#c0c5ce;">$ cargo install cobalt-bin
-</span></pre>
+<code><span style="color:#c0c5ce;">$ cargo install cobalt-bin
+</span></code></pre>
 <h2>Building</h2>
 <p>To re-build the <code>wasmtime.dev</code> website, run</p>
 <pre style="background-color:#2b303b;">
-<span style="color:#c0c5ce;">cobalt build
-</span></pre>
+<code><span style="color:#c0c5ce;">cobalt build
+</span></code></pre>
 <p>The built site will be in <code>_site/</code>.</p>
 <h2>Development</h2>
 <p>To start a local server and rebuild the website whenever a file is changed, run</p>
 <pre style="background-color:#2b303b;">
-<span style="color:#c0c5ce;">cobalt serve
-</span></pre>
+<code><span style="color:#c0c5ce;">cobalt serve
+</span></code></pre>
 <p>and visit http://localhost:1024/ in your browser.</p>

--- a/_site/index.html
+++ b/_site/index.html
@@ -75,8 +75,8 @@ section pre {
 <p>It looks like you’re running macOS or Linux. To download and install Wasmtime,
 run the following in your terminal, then follow the on-screen instructions.</p>
 <pre style="background-color:#2b303b;">
-<span style="color:#8fa1b3;">curl</span><span style="color:#c0c5ce;"> https://wasmtime.dev/install.sh</span><span style="color:#bf616a;"> -sSf </span><span style="color:#c0c5ce;">| </span><span style="color:#8fa1b3;">bash
-</span></pre>
+<code><span style="color:#8fa1b3;">curl</span><span style="color:#c0c5ce;"> https://wasmtime.dev/install.sh</span><span style="color:#bf616a;"> -sSf </span><span style="color:#c0c5ce;">| </span><span style="color:#8fa1b3;">bash
+</span></code></pre>
 <p>You can also download binaries directly from the <a href="https://github.com/bytecodealliance/wasmtime/releases">GitHub
 Releases</a> page.</p>
 </div>
@@ -87,15 +87,15 @@ following, and then follow the onscreen instructions.</p>
 <p>If you’re a Windows Subsystem for Linux user run the following in your terminal,
 then follow the on-screen instructions to install Wasmtime.</p>
 <pre style="background-color:#2b303b;">
-<span style="color:#8fa1b3;">curl</span><span style="color:#c0c5ce;"> https://wasmtime.dev/install.sh</span><span style="color:#bf616a;"> -sSf </span><span style="color:#c0c5ce;">| </span><span style="color:#8fa1b3;">bash
-</span></pre>
+<code><span style="color:#8fa1b3;">curl</span><span style="color:#c0c5ce;"> https://wasmtime.dev/install.sh</span><span style="color:#bf616a;"> -sSf </span><span style="color:#c0c5ce;">| </span><span style="color:#8fa1b3;">bash
+</span></code></pre>
 </div>
 <div id="platform-instructions-default" class="db">
 <p>If you’re running macOS or Linux, download and install Wasmtime by running the
 following in your terminal and following the on-screen instructions.</p>
 <pre style="background-color:#2b303b;">
-<span style="color:#8fa1b3;">curl</span><span style="color:#c0c5ce;"> https://wasmtime.dev/install.sh</span><span style="color:#bf616a;"> -sSf </span><span style="color:#c0c5ce;">| </span><span style="color:#8fa1b3;">bash
-</span></pre>
+<code><span style="color:#8fa1b3;">curl</span><span style="color:#c0c5ce;"> https://wasmtime.dev/install.sh</span><span style="color:#bf616a;"> -sSf </span><span style="color:#c0c5ce;">| </span><span style="color:#8fa1b3;">bash
+</span></code></pre>
 <hr />
 <p>If you are running Windows, download and run the <a href="https://github.com/bytecodealliance/wasmtime/releases/download/dev/wasmtime-dev-x86_64-windows.msi">Wasmtime
 Installer</a>
@@ -113,17 +113,17 @@ then follow the on-screen instructions.</p>
 installed</a> then you can take some Rust
 source code:</p>
 <pre style="background-color:#2b303b;">
-<span style="color:#b48ead;">fn </span><span style="color:#8fa1b3;">main</span><span style="color:#c0c5ce;">() {
+<code><span style="color:#b48ead;">fn </span><span style="color:#8fa1b3;">main</span><span style="color:#c0c5ce;">() {
 </span><span style="color:#c0c5ce;">    println!(&quot;</span><span style="color:#a3be8c;">Hello, world!</span><span style="color:#c0c5ce;">&quot;);
 </span><span style="color:#c0c5ce;">}
-</span></pre>
+</span></code></pre>
 <p>and compile/run it with:</p>
 <pre style="background-color:#2b303b;">
-<span style="color:#8fa1b3;">$</span><span style="color:#c0c5ce;"> rustup target add wasm32-wasi
+<code><span style="color:#8fa1b3;">$</span><span style="color:#c0c5ce;"> rustup target add wasm32-wasi
 </span><span style="color:#8fa1b3;">$</span><span style="color:#c0c5ce;"> rustc hello.rs</span><span style="color:#bf616a;"> --target</span><span style="color:#c0c5ce;"> wasm32-wasi
 </span><span style="color:#8fa1b3;">$</span><span style="color:#c0c5ce;"> wasmtime hello.wasm
 </span><span style="color:#8fa1b3;">Hello,</span><span style="color:#c0c5ce;"> world!
-</span></pre>
+</span></code></pre>
 </div>
 </section>
 <section>

--- a/_site/install.sh
+++ b/_site/install.sh
@@ -229,13 +229,13 @@ upgrade_is_ok() {
   local install_dir="$2"
   local is_dev_install="$3"
 
-  local wasmtime_bin="$install_dir/wasmtime"
+  local wasmtime_bin="$install_dir/bin/wasmtime"
 
   if [[ -n "$install_dir" && -x "$wasmtime_bin" ]]; then
     local prev_version="$( ($wasmtime_bin --version 2>/dev/null || echo 0.1) | sed -E 's/^.*([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')"
     # if this is a local dev install, skip the equality check
     # if installing the same version, this is a no-op
-    if [ "$is_dev_install" != "true" ] && [ "$prev_version" == "$will_install_version" ]; then
+    if [ "$is_dev_install" != "true" ] && [ "v$prev_version" == "$will_install_version" ]; then
       eprintf "Version $will_install_version already installed"
       return 1
     fi

--- a/install.sh
+++ b/install.sh
@@ -229,13 +229,13 @@ upgrade_is_ok() {
   local install_dir="$2"
   local is_dev_install="$3"
 
-  local wasmtime_bin="$install_dir/wasmtime"
+  local wasmtime_bin="$install_dir/bin/wasmtime"
 
   if [[ -n "$install_dir" && -x "$wasmtime_bin" ]]; then
     local prev_version="$( ($wasmtime_bin --version 2>/dev/null || echo 0.1) | sed -E 's/^.*([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')"
     # if this is a local dev install, skip the equality check
     # if installing the same version, this is a no-op
-    if [ "$is_dev_install" != "true" ] && [ "$prev_version" == "$will_install_version" ]; then
+    if [ "$is_dev_install" != "true" ] && [ "v$prev_version" == "$will_install_version" ]; then
       eprintf "Version $will_install_version already installed"
       return 1
     fi


### PR DESCRIPTION
Hello.

It seems that `install.sh` doesn't correctly detect an existing up-to-date installation and always downloads and installs the binaries.

The isssue is twofold:
1. https://github.com/bytecodealliance/wasmtime.dev/blob/99b039e7c05b5880df034a929ccde74d8daa7977/install.sh#L232 the binary is expected in `$install_dir/wasmtime` but it's actually in `$instal_dir/bin/wasmtime` (as per https://github.com/bytecodealliance/wasmtime.dev/blob/99b039e7c05b5880df034a929ccde74d8daa7977/install.sh#L460)
2. https://github.com/bytecodealliance/wasmtime.dev/blob/99b039e7c05b5880df034a929ccde74d8daa7977/install.sh#L238 `$prev_version` will be something like `9.0.3` (as the binary reports) but `$will_install_version` will be `v9.0.3` (as the github tag), so the comparison needs to be adjusted - here I'm not sure what possible cases need to be handled, so I just added the `v` in front of the local version, which seems to work for all releases so far except for this one https://github.com/bytecodealliance/wasmtime/releases/tag/v0.15.0 (notice the release name missing the leading `v`)

This might be related to the difference between the tarball layout and installation layout as mentioned here https://github.com/bytecodealliance/wasmtime/issues/6543