### PR TITLE
install.sh: support compactified JSON from GitHub API.

### DIFF
--- a/_site/install.sh
+++ b/_site/install.sh
@@ -41,8 +41,9 @@
 
 get_latest_release() {
   curl --silent "https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest" | \
-    grep tag_name | \
-    cut -d '"' -f 4
+    tr -d '\n' | \
+    sed 's/.*tag_name": *"//' | \
+    sed 's/".*//'
 }
 
 release_url() {

--- a/install.sh
+++ b/install.sh
@@ -41,8 +41,9 @@
 
 get_latest_release() {
   curl --silent "https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest" | \
-    grep tag_name | \
-    cut -d '"' -f 4
+    tr -d '\n' | \
+    sed 's/.*tag_name": *"//' | \
+    sed 's/".*//'
 }
 
 release_url() {


### PR DESCRIPTION
In bytecodealliance/wasmtime#7377, we saw a case where a user gets compactified (single-line) JSON responses from the GitHub API. The `install.sh` logic to get the latest Wasmtime release version currently does text-munging that assumes a multiline (pretty-printed) JSON layout. This PR instead uses `tr` and `sed` to get the version number from either input format (thanks to @bjorn3 for the exact invocations!).

Fixes bytecodealliance/wasmtime#7377.