### PR TITLE
Removes any potential user endline configuration

### DIFF
--- a/_site/install.sh
+++ b/_site/install.sh
@@ -40,7 +40,7 @@
 # either expressed or implied, of the FreeBSD Project.
 
 get_latest_release() {
-  curl --silent "https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest" | \
+  curl -w '' --silent "https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest" | \
     tr -d '\n' | \
     sed 's/.*tag_name": *"//' | \
     sed 's/".*//'

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@
 # either expressed or implied, of the FreeBSD Project.
 
 get_latest_release() {
-  curl --silent "https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest" | \
+  curl -w '' --silent "https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest" | \
     grep tag_name | \
     cut -d '"' -f 4
 }


### PR DESCRIPTION
I discovered an issue with my curl config (I have a `.curlrc` file with `-w "\n"` in it) where it was attempting to untar `\n<file name>`. This change corrects this behavior so it will unset any user configuration. 

Alternatively, `-q` or `--disable` could be used, but users might have specific configuration related to some other needed functionality that might break curl entirely if those were used.