### PR TITLE
Add RISC-V support to install.sh

### DIFF
--- a/_site/install.sh
+++ b/_site/install.sh
@@ -471,6 +471,12 @@ get_architecture() {
         arm64)
             arch=aarch64
             ;;
+        # Linux identifies RISC-V as "riscv64", but wasmtime tags
+        # their releases using the toolchain name "riscv64gc"
+        # When encountering riscv64, map it to that name.
+        riscv64)
+            arch=riscv64gc
+            ;;
     esac
     echo "$arch"
 }
@@ -487,6 +493,10 @@ check_architecture() {
 
   # Otherwise, check the matrix of OS/architecture support.
   case "$arch/$os" in
+      # See the comment in get_architecture regarding this name.
+      riscv64gc/Linux)
+          return 0
+          ;;
       aarch64/Linux)
           return 0
           ;;
@@ -501,7 +511,7 @@ check_architecture() {
           ;;
   esac
 
-  error "Sorry! Wasmtime currently only provides pre-built binaries for x86_64 (Linux, macOS, Windows), aarch64 (Linux, macOS), and s390x (Linux)."
+  error "Sorry! Wasmtime currently only provides pre-built binaries for x86_64 (Linux, macOS, Windows), aarch64 (Linux, macOS), s390x (Linux) and riscv64 (Linux)."
   return 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -471,6 +471,12 @@ get_architecture() {
         arm64)
             arch=aarch64
             ;;
+        # Linux identifies RISC-V as "riscv64", but wasmtime tags
+        # their releases using the toolchain name "riscv64gc"
+        # When encountering riscv64, map it to that name.
+        riscv64)
+            arch=riscv64gc
+            ;;
     esac
     echo "$arch"
 }
@@ -487,6 +493,10 @@ check_architecture() {
 
   # Otherwise, check the matrix of OS/architecture support.
   case "$arch/$os" in
+      # See the comment in get_architecture regarding this name.
+      riscv64gc/Linux)
+          return 0
+          ;;
       aarch64/Linux)
           return 0
           ;;
@@ -501,7 +511,7 @@ check_architecture() {
           ;;
   esac
 
-  error "Sorry! Wasmtime currently only provides pre-built binaries for x86_64 (Linux, macOS, Windows), aarch64 (Linux, macOS), and s390x (Linux)."
+  error "Sorry! Wasmtime currently only provides pre-built binaries for x86_64 (Linux, macOS, Windows), aarch64 (Linux, macOS), s390x (Linux) and riscv64 (Linux)."
   return 1
 }
 


### PR DESCRIPTION
👋 Hey,

This PR adds support for the RISC-V Architecture to the install.sh script. Wasmtime already publishes pre-compiled binaries for this target, we just need to add some minimal support to get it working here.

There is a slight wrinkle, Linux identifies RISC-V as "riscv64", but wasmtime uses the name "riscv64gc". So this PR adds a mapping from the former to the latter when fetching the binaries. As mentioned in https://github.com/bytecodealliance/wasmtime/issues/7580#issuecomment-1825587887, I'm not entirely sure if this is the correct way to go about things, but it seems like a fairly minimal change.

I've tested this on a native RISC-V machine running Debian 13 (Trixie).

Closes: https://github.com/bytecodealliance/wasmtime/issues/7580