### PR TITLE
Update index.md to reflect changes to Rust's wasi targets

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -119,8 +119,8 @@ source code:</p>
 </span></code></pre>
 <p>and compile/run it with:</p>
 <pre style="background-color:#2b303b;">
-<code><span style="color:#8fa1b3;">$</span><span style="color:#c0c5ce;"> rustup target add wasm32-wasi
-</span><span style="color:#8fa1b3;">$</span><span style="color:#c0c5ce;"> rustc hello.rs</span><span style="color:#bf616a;"> --target</span><span style="color:#c0c5ce;"> wasm32-wasi
+<code><span style="color:#8fa1b3;">$</span><span style="color:#c0c5ce;"> rustup target add wasm32-wasip1
+</span><span style="color:#8fa1b3;">$</span><span style="color:#c0c5ce;"> rustc hello.rs</span><span style="color:#bf616a;"> --target</span><span style="color:#c0c5ce;"> wasm32-wasip1
 </span><span style="color:#8fa1b3;">$</span><span style="color:#c0c5ce;"> wasmtime hello.wasm
 </span><span style="color:#8fa1b3;">Hello,</span><span style="color:#c0c5ce;"> world!
 </span></code></pre>

--- a/index.md
+++ b/index.md
@@ -108,8 +108,8 @@ fn main() {
 and compile/run it with:
 
 ```sh
-$ rustup target add wasm32-wasi
-$ rustc hello.rs --target wasm32-wasi
+$ rustup target add wasm32-wasip1
+$ rustc hello.rs --target wasm32-wasip1
 $ wasmtime hello.wasm
 Hello, world!
 ```


### PR DESCRIPTION
After the [Changes to Rust's WASI targets](https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html), the website can be updated to meet the new requirements. 
The github `README.md` for wasmtime repo already reflects these and only couple of months are left before `wasm32-wasi` is removed.