### PR TITLE
fix: dead link

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -160,7 +160,7 @@ on massive servers with many concurrent instances, we've got you covered.</p>
 environment through the <a href="https://wasi.dev">WASI standard</a>.</p>
 </li>
 <li>
-<p><strong><a href="https://docs.wasmtime.dev/stability-wasm-proposals-support.html">Standards Compliant</a></strong>. Wasmtime passes the <a href="https://github.com/WebAssembly/testsuite">official WebAssembly test
+<p><strong><a href="https://docs.wasmtime.dev/stability-wasm-proposals.html">Standards Compliant</a></strong>. Wasmtime passes the <a href="https://github.com/WebAssembly/testsuite">official WebAssembly test
 suite</a>, implements the <a href="https://github.com/WebAssembly/wasm-c-api">official C
 API of wasm</a>, and implements
 <a href="https://github.com/WebAssembly/proposals">future proposals to WebAssembly</a> as

--- a/index.md
+++ b/index.md
@@ -163,7 +163,7 @@ Hello, world!
 [Secure]: https://docs.wasmtime.dev/security.html
 [Configurable]: https://docs.rs/wasmtime/latest/wasmtime/struct.Config.html
 [WASI]: https://docs.rs/wasmtime-wasi/latest/wasmtime_wasi/
-[Standards Compliant]: https://docs.wasmtime.dev/stability-wasm-proposals-support.html
+[Standards Compliant]: https://docs.wasmtime.dev/stability-wasm-proposals.html
 
 </div>
 </section>


### PR DESCRIPTION
The current one leads to a 404 page.