### PR TITLE
ci: update all actions to latest version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Install cobalt
       run: cargo install cobalt-bin
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
 
     - name: Check that build is up to date
       run: rm -rf _site/ && cobalt build && git diff --exit-code

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,14 +25,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup Pages
-        uses: actions/configure-pages@v1
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           # Upload built site.
           path: '_site'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
fixes previous deploy failure due to deprecated version of upload-artifact:

https://github.com/bytecodealliance/wasmtime.dev/actions/runs/18503514649