### PR TITLE
Add a `.well-known/security.txt` file following RFC 9116

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:security@bytecodealliance.org
+Contact: https://bytecodealliance.org/security
+Policy: https://docs.wasmtime.dev/security-disclosure.html
+Preferred-Languages: en
+Encryption: https://bytecodealliance.org/.well-known/pgp-key.txt
+Expires: 2026-12-31T23:59:59Z

--- a/_cobalt.yml
+++ b/_cobalt.yml
@@ -6,3 +6,4 @@ posts:
   rss: rss.xml
 ignore:
   - README.md
+  - "!.well-known"

--- a/_site/.well-known/security.txt
+++ b/_site/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:security@bytecodealliance.org
+Contact: https://bytecodealliance.org/security
+Policy: https://docs.wasmtime.dev/security-disclosure.html
+Preferred-Languages: en
+Encryption: https://bytecodealliance.org/.well-known/pgp-key.txt
+Expires: 2026-12-31T23:59:59Z


### PR DESCRIPTION
[RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) describes a standardized way to publish information on how to report security vulnerabilities. We should use it.